### PR TITLE
Remove single quotes preventing path expansion

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -91,4 +91,4 @@ jobs:
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.
       run: >-
-        gh release upload '${{ github.ref_name }}' 'dist/**' --repo '${{ github.repository }}'
+        gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'


### PR DESCRIPTION
Fixes release of signed python package into "github releases"