### PR TITLE
Introduce nix to build and test the library code

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# shellcheck shell=bash
+
+# This file is executed by direnv
+# https://search.nixos.org/packages?channel=23.05&show=direnv
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,134 @@
+{
+  description = "A minimal Python ORM wrapper for the Odoo API.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.systems.url = "github:nix-systems/default";
+  inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
+  inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = { self, nixpkgs, systems, treefmt-nix }:
+    let
+      # __forSystems = nixpkgs.lib.genAttrs (import systems);
+      __forSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" ];
+      __forPackages = __forSystems (system: nixpkgs.legacyPackages.${system});
+      # Helper creating attribute sets for each supported system.
+      eachSystem = mapFn: __forSystems (system: mapFn __forPackages.${system});
+
+      pyProject = nixpkgs.lib.importTOML ./pyproject.toml;
+    in
+    {
+      packages = eachSystem (pkgs: {
+        default = pkgs.python3Packages.buildPythonPackage {
+          pyproject = true;
+          pname = pyProject.project.name;
+          inherit (pyProject.project) version;
+
+          src = ./.;
+
+          build-system = [ pkgs.python3Packages.setuptools ];
+          pythonImportsCheck = pyProject.tool.setuptools.packages;
+
+          meta = {
+            inherit (pyProject.project) description;
+            inherit (pyProject.project.urls) homepage;
+            license = pkgs.lib.licenses.mit;
+          };
+        };
+      });
+
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShellNoCC {
+          packages =
+            let
+              customPython = (pkgs.python3.override {
+                packageOverrides = packagesFinal: _: {
+                  betterOdooApiWrapper = packagesFinal.mkPythonEditablePackage {
+                    pname = pyProject.project.name;
+                    inherit (pyProject.project) version;
+                    root = "$REPO_ROOT";
+                  };
+                };
+              }).withPackages (ps: [ ps.betterOdooApiWrapper ]);
+            in
+            [
+              pkgs.git
+              customPython
+              #
+              (pkgs.writeShellApplication {
+                name = "invoke-tests";
+                runtimeInputs = [ pkgs.nix-fast-build ];
+                text = ''
+                  cd "$REPO_ROOT" && nix-fast-build
+                '';
+              })
+            ];
+
+          shellHook = ''
+            # ERROR; Assumes the devshell is executed from a (sub-)directory of the repository.
+            # This command will give the wrong result when ran from another repository eg, 
+            # 'nix develop ../projects/other-project-flake'
+            export REPO_ROOT="$(git rev-parse --show-toplevel)"
+          '';
+        };
+      });
+
+      formatter = eachSystem (pkgs:
+        (treefmt-nix.lib.mkWrapper (pkgs) {
+          projectRootFile = "flake.nix";
+
+          programs.nixpkgs-fmt.enable = true;
+          # Python linting/formatting
+          programs.ruff.check = true;
+          programs.ruff.format = true;
+          # Python static typing checker
+          programs.mypy = {
+            enable = true;
+            directories = {
+              "wrapper" = {
+                directory = ".";
+                modules = [ "BetterOdooApiWrapper" ];
+                extraPythonPackages = [ ];
+              };
+            };
+          };
+        }));
+
+
+      # Run integration tests with;
+      # nix run nixpkgs#nix-fast-build
+      # [CI builds] nix run nixpkgs#nix-fast-build -- --no-nom
+      checks = eachSystem (pkgs: {
+        integration = pkgs.testers.runNixOSTest ({ ... }: {
+          name = "better-odoo-api integration tests";
+          nodes.machine = { pkgs, ... }: {
+            services.odoo.enable = true;
+            services.odoo.autoInit = true;
+            services.odoo.autoInitExtraFlags = [
+              "-i hr" # includes hr.employee model
+            ];
+            services.odoo.settings = {
+              options.http_enable = true;
+              options.http_interface = "127.0.0.1";
+              # options.workers = 1; # Currently broken due to wrapping binary entrypoint "odoo"
+            };
+            environment.systemPackages = [
+              (pkgs.python3.withPackages (ps: [
+                ps.python-dotenv
+                self.outputs.packages.${pkgs.system}.default
+              ]))
+            ];
+          };
+
+          testScript = ''
+            machine.wait_for_unit("odoo.service")
+            machine.wait_for_open_port(8069) # Default odoo port
+            # Find tests in all files including integration tests, because we're in an integration environment.
+            machine.succeed("""
+              cd '${self}' \
+              && ODOO_URL="http://127.0.0.1:8069" ODOO_DB="odoo" ODOO_USER="admin" ODOO_PASS="admin" python -m unittest discover -p '*.py'
+            """)
+          '';
+        });
+      });
+    };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "BetterOdooApiWrapper"
 version = "0.1.1"
@@ -20,8 +16,9 @@ homepage = "https://github.com/europowergenerators/BetterOdooApiWrapper"
 Documentation = "https://github.com/europowergenerators/BetterOdooApiWrapper"
 "Issue tracker" = "https://github.com/europowergenerators/BetterOdooApiWrapper/issues"
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["BetterOdooApiWrapper*"]  # package names should match these glob patterns (["*"] by default)
-exclude = []  # exclude packages matching these glob patterns (empty by default)
-namespaces = true  # to disable scanning PEP 420 namespaces (true by default)
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["BetterOdooApiWrapper"]


### PR DESCRIPTION
Launch development environment on nix-installed machine with `nix develop`.
Launch tests from development environment with `invoke-tests` or `nix run .#checks.x86_64-linux.integration.driverInteractive` to enter the test environment interactively.

Some tests fail because they expect data from our own odoo instance. The database in the integration environment is empty/only has demo data.